### PR TITLE
[ISSUE-7] Add support for comparison refs like head or exact hashes

### DIFF
--- a/gomp.py
+++ b/gomp.py
@@ -291,12 +291,12 @@ def show_recut_offer():
 
 def branch_exists(branch):
     verify = run(
-        ['git', 'show-ref', branch],
+        ['git', 'cat-file', '-t', branch],
         stdout=PIPE,
         universal_newlines=True,
         check=False,
-    ).stdout
-    return verify != ''
+    ).stdout.strip()
+    return verify == 'commit'
 
 
 # Basic command input parser

--- a/test/expected_output/hash_vs_ref.txt
+++ b/test/expected_output/hash_vs_ref.txt
@@ -1,0 +1,11 @@
+
+[1mfeature~2 (src)                        [0m  [1m5950d06 (dest)                         [0m
+[1m---------------------------------------[0m  [1m---------------------------------------[0m
+[95m41de0ff Commit c                       [0m  [37m                                       [0m
+[93mef4dedb Commit 3                       [0m  [93m5950d06 Commit 3                       [0m
+[95m8513c09 Commit b                       [0m  [91md1d1e2a Commit II                      [0m
+[95m083cf2e Commit a                       [0m  [91m0f8a43e Commit I                       [0m
+[92m2349725 Commit 2                       [0m  [92m2349725 Commit 2                       [0m
+[92mc0aadea Commit 1                       [0m  [92mc0aadea Commit 1                       [0m
+[92mce9dac8 Commit 0                       [0m  [92mce9dac8 Commit 0                       [0m
+

--- a/test/test.py
+++ b/test/test.py
@@ -47,6 +47,17 @@ class GOMPIntegrationTestCase(unittest.TestCase):
         f.close()
         self.assertEqual(gomp_output, expected_output)
 
+    def test_hash_vs_ref(self):
+        gomp_output = run(['python3', '../gomp.py', 'feature~2', '5950d06', '--cols', NUM_COLS],
+                          stdout=PIPE,
+                          universal_newlines=True,
+                          check=False,
+                          ).stdout
+        f = open('expected_output/hash_vs_ref.txt', 'r')
+        expected_output = f.read()
+        f.close()
+        self.assertEqual(gomp_output, expected_output)
+
     def test_help(self):
         gomp_output = run(['python3', '../gomp.py', '-h'],
                           stdout=PIPE,


### PR DESCRIPTION
Summary:
The git show-ref command would not allow inputs such as "head" or
"head~3" as inputs. The branch existence check has been modified to
allow support for these inputs.

Test Plan:
Added test that uses `feature~2` syntax and exact commit hash.