### PR TITLE
just corrected shebang

### DIFF
--- a/gomp/gomp.py
+++ b/gomp/gomp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Side by side branch diffing from last common hash:
 #     gomp staging rc

--- a/gomp/gomp.py
+++ b/gomp/gomp.py
@@ -1,4 +1,4 @@
-#!usr/bin/env python
+#!/usr/bin/env python
 
 # Side by side branch diffing from last common hash:
 #     gomp staging rc

--- a/legacy/gomp.py
+++ b/legacy/gomp.py
@@ -1,4 +1,4 @@
-#!usr/bin/env python
+#!/usr/bin/env python
 # Side by side branch diffing from last common hash:
 #   gomp staging rc
 # Show color code:

--- a/legacy/gomp.py
+++ b/legacy/gomp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Side by side branch diffing from last common hash:
 #   gomp staging rc
 # Show color code:


### PR DESCRIPTION
I use gomp.py (legacy) without alias, so:


```bash
alex@vosjod::~/bin $ ./gomp
-bash: ./gomp: usr/bin/env: bad interpreter: No such file or directory

alex@vosjod::~/bin $ vi gomp
alex@vosjod::~/bin $ ./gomp
usage: gomp [-h] [--key] [--recut] [src] dest
gomp: error: too few arguments
```
