### PR TITLE
[PATCH] Enable color functionality for Windows

### DIFF
--- a/gomp/gomp.py
+++ b/gomp/gomp.py
@@ -17,6 +17,7 @@ import os
 import re
 from subprocess import run, PIPE
 import argparse
+import platform
 
 #############
 ### ENUMS ###
@@ -388,4 +389,6 @@ def process_commands():
 
 
 if __name__ == '__main__':
+    if platform.system() == "Windows":
+        os.system('color')
     process_commands()


### PR DESCRIPTION
I have been using GOMP on WSL (Windows Subsystem for Linux) for a while now and it's been great. I now need to use the "Window-side" terminals like Git Bash and Powershell, and this single line change enables the color functionality of GOMP to work in those terminals.