### PR TITLE
Fix gomp if git is configured to always color

### DIFF
--- a/gomp/gomp.py
+++ b/gomp/gomp.py
@@ -353,13 +353,13 @@ def process_commands():
 
     # Grab inline history of both branches
     source_history = run(
-        ['git', '--no-pager', 'log', src, '--pretty=oneline'],
+        ['git', '--no-pager', 'log', src, '--pretty=oneline', '--no-color'],
         stdout=PIPE,
         universal_newlines=True,
         check=False,
     ).stdout.splitlines()
     destination_history = run(
-        ['git', '--no-pager', 'log', dest, '--pretty=oneline'],
+        ['git', '--no-pager', 'log', dest, '--pretty=oneline', '--no-color'],
         stdout=PIPE,
         universal_newlines=True,
         check=False,

--- a/test/expected_output/help.txt
+++ b/test/expected_output/help.txt
@@ -4,7 +4,7 @@ positional arguments:
   src          Left side branch
   dest         Right side branch
 
-optional arguments:
+options:
   -h, --help   show this help message and exit
   --key        Display with color code
   --recut      Recut view


### PR DESCRIPTION
If git config is set to always show colors, it will break the output. Pass `--no-color` to force no colors. Repro by setting `~/.gitconfig`

```
[color]
  diff = always
```

Also update expected argparse help text for tests.